### PR TITLE
Use v4.ifconfig.co for lat/lon as other service is not working

### DIFF
--- a/termtrack/cli.py
+++ b/termtrack/cli.py
@@ -119,9 +119,9 @@ def render(
         observer_latitude = None
         observer_longitude = None
         if me and observer is None:
-            location_data = get("http://ip-api.com/json").json()
-            observer_latitude = location_data['lat']
-            observer_longitude = location_data['lon']
+            location_data = get("https://v4.ifconfig.co/json").json()
+            observer_latitude = location_data['latitude']
+            observer_longitude = location_data['longitude']
         if observer is not None:
             obs_latlon = observer.split()
             observer_latitude = float(obs_latlon[0])


### PR DESCRIPTION
Fixes the following error as it appears ip-api.com is no longer online:

requests.exceptions.ConnectionError: HTTPConnectionPool(host='ip-api.com', port=80): Max retries exceeded with url: /json (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x
10390f410>: Failed to establish a new connection: [Errno 61] Connection refused'))